### PR TITLE
Potential fix for code scanning alert no. 7: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -275,7 +275,13 @@ def _generate_address(private_key: ec.EllipticCurvePrivateKey, addr_type: str) -
 
 # Helper Functions
 def generate_brain_wallet(passphrase: str) -> tuple[str, str, str]:
-    private_key_bytes = hashlib.sha256(passphrase.encode('utf-8')).digest()
+    private_key_bytes = hashlib.pbkdf2_hmac(
+        'sha256',
+        passphrase.encode('utf-8'),
+        b'brain-wallet',
+        200_000,
+        dklen=32,
+    )
     private_key = ec.derive_private_key(int.from_bytes(private_key_bytes, 'big'), ec.SECP256K1())
     return _generate_address(private_key, "P2PKH")
 


### PR DESCRIPTION
Potential fix for [https://github.com/yanncarlier/btcapi/security/code-scanning/7](https://github.com/yanncarlier/btcapi/security/code-scanning/7)

In general, to fix this issue we should not use a fast hash like SHA-256 directly on a password or passphrase when deriving secrets. Instead, we should apply a computationally expensive password hashing / key derivation function (such as Argon2, scrypt, bcrypt, or PBKDF2) with a reasonably large iteration count or cost parameters. For deterministic key derivation (needed here so that the same passphrase generates the same wallet), we can use PBKDF2-HMAC with SHA-256 and a fixed, well-documented “brain wallet” salt and iteration count, then take the output key material as the basis for the private key. This preserves determinism but makes brute-force significantly more expensive.

The best minimal-change fix here is to replace `hashlib.sha256(passphrase.encode('utf-8')).digest()` with a call to `hashlib.pbkdf2_hmac`, using SHA-256 as the underlying PRF, a fixed salt (since we need determinism), and a sufficiently high iteration count (for example, 200_000, which is a commonly recommended lower bound today). We only need to change the implementation of `generate_brain_wallet` in `api/main.py`; the rest of the code that calls `_generate_address` and uses `private_key_bytes` can remain unchanged because it still receives a 32-byte string. No new third-party dependencies are necessary, since `hashlib.pbkdf2_hmac` is in the standard library. Concretely, we will update line 278 to compute `private_key_bytes` using `hashlib.pbkdf2_hmac('sha256', passphrase.encode('utf-8'), b'brain-wallet', 200_000, dklen=32)` (the salt bytes and iteration count can be given descriptive names if desired, but to keep the change minimal we will inline them).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
